### PR TITLE
Kubelet --provider-id should take precedence in initial node status

### DIFF
--- a/pkg/kubelet/kubelet_node_status.go
+++ b/pkg/kubelet/kubelet_node_status.go
@@ -322,7 +322,7 @@ func (kl *Kubelet) initialNode() (*v1.Node, error) {
 		}
 	} else {
 		node.Spec.ExternalID = kl.hostname
-		if kl.autoDetectCloudProvider {
+		if kl.autoDetectCloudProvider && node.Spec.ProviderID == "" {
 			// If no cloud provider is defined - use the one detected by cadvisor
 			info, err := kl.GetCachedMachineInfo()
 			if err == nil {


### PR DESCRIPTION
**What this PR does / why we need it**:
Node providerID passed in via `--provider-id` in the kubelet should take precedence in the initial node spec instead of being overwritten afterwards. This should not break APIs for anyone as far as I know since [auto detecting cloud providers](https://github.com/kubernetes/kubernetes/blob/master/pkg/kubelet/kubelet.go#L464) is an alpha feature. 

